### PR TITLE
PSPAYPAL-678 - Fixed PHP 8.1 problem

### DIFF
--- a/src/Model/BaseModel.php
+++ b/src/Model/BaseModel.php
@@ -6,6 +6,7 @@ use Error;
 
 trait BaseModel
 {
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return (object) array_filter((array) $this, static function ($var) {


### PR DESCRIPTION
This code triggers a Deprecated warning in PHP 8.1 - breaking PayPal Express usage:
Return type of OxidSolutionCatalysts\PayPalApi\Model\Orders\OrderRequest::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in <b>/var/www/html/vendor/oxid-solution-catalysts/paypal-client/src/Model/BaseModel.php</b>

Correct way to change this for PHP 8.1 would be to declare the return type mixed:

`public function jsonSerialize(): mixed`

BUT that would break backwards-compatibility since return type mixed is only support since PHP 8.0.

#[\ReturnTypeWillChange] does not break backwards-compatibility