### PR TITLE
PSPAYPAL-680 - add missing fields to vaultResponse data mapping

### DIFF
--- a/generated/Model/Orders/VaultResponse.php
+++ b/generated/Model/Orders/VaultResponse.php
@@ -75,6 +75,15 @@ class VaultResponse implements JsonSerializable
         if (isset($data['status'])) {
             $this->status = $data['status'];
         }
+        if (isset($data['customer'])) {
+            $this->customer = $data['customer'];
+        }
+        if (isset($data['links'])) {
+            $this->links = [];
+            foreach ($data['links'] as $item) {
+                $this->links[] = $item;
+            }
+        }
     }
 
     public function __construct(array $data = null)


### PR DESCRIPTION
In order for the Vaulting feature to work, these additional fields need to be mapped in the VaultResponse class.
Reference: https://developer.paypal.com/docs/checkout/save-payment-methods/during-purchase/js-sdk/paypal/#link-captureorder